### PR TITLE
[fix] upper bounds on some data subquery counts

### DIFF
--- a/src/v2/query/queryBuilderV2.ts
+++ b/src/v2/query/queryBuilderV2.ts
@@ -638,8 +638,8 @@ export class QueryBuilderV2 {
 
   private updateSubqueryCount(type: DataSubqueryType) {
     this.dataSubqueryCount.total++;
-    if (this.dataSubqueryCount.total > ConstantsV2.MaxDataQuerySize) {
-      throw new Error(`Cannot add more than ${ConstantsV2.MaxDataQuerySize} subqueries`);
+    if (this.dataSubqueryCount.total >= ConstantsV2.MaxDataQuerySize) {
+      throw new Error(`Cannot add more than ${ConstantsV2.MaxDataQuerySize - 1} subqueries`);
     }
     switch (type) {
       case DataSubqueryType.Header:
@@ -647,14 +647,14 @@ export class QueryBuilderV2 {
         break;
       case DataSubqueryType.Account:
         this.dataSubqueryCount.account++;
-        if (this.dataSubqueryCount.account > ConstantsV2.MaxSameSubqueryType) {
-          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType} Account subqueries`);
+        if (this.dataSubqueryCount.account + this.dataSubqueryCount.storage + this.dataSubqueryCount.solidityNestedMapping >= ConstantsV2.MaxSameSubqueryType) {
+          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType - 1} Account + Storage + Nested Mapping subqueries`);
         }
         break;
       case DataSubqueryType.Storage:
         this.dataSubqueryCount.storage++;
-        if (this.dataSubqueryCount.storage > ConstantsV2.MaxSameSubqueryType) {
-          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType} Storage subqueries`);
+        if (this.dataSubqueryCount.account + this.dataSubqueryCount.storage + this.dataSubqueryCount.solidityNestedMapping >= ConstantsV2.MaxSameSubqueryType) {
+          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType - 1} Account + Storage + Nested Mapping subqueries`);
         }
         break;
       case DataSubqueryType.Transaction:
@@ -671,8 +671,8 @@ export class QueryBuilderV2 {
         break;
       case DataSubqueryType.SolidityNestedMapping:
         this.dataSubqueryCount.solidityNestedMapping++;
-        if (this.dataSubqueryCount.solidityNestedMapping > ConstantsV2.MaxSameSubqueryType) {
-          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType} Nested Mapping subqueries`);
+        if (this.dataSubqueryCount.account + this.dataSubqueryCount.storage + this.dataSubqueryCount.solidityNestedMapping >= ConstantsV2.MaxSameSubqueryType) {
+          throw new Error(`Cannot add more than ${ConstantsV2.MaxSameSubqueryType - 1} Account + Storage + Nested Mapping subqueries`);
         }
         break;
       default:


### PR DESCRIPTION
Not ideal, and the actual logic around upper bounds is more complicated (e.g., how many storage subqueries did you do to the same account), but this PR adds a conservative upper bound on all data subquery counts.