### PR TITLE
Move targetChainId to Axiom initialization

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,5 @@
   "useTabs": false,
   "semi": true,
   "trailingComma": "all",
-  "bracketSpacing": true,
+  "bracketSpacing": true
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -11,10 +11,22 @@ export interface AxiomConfig {
   providerUri: string;
 
   /**
+   * Provider URI for the target chain
+   */
+  targetProviderUri?: string;
+  
+  /**
+   * Backup provider URIs
+   */
+  backupProviderUri?: string;
+  backupTargetProviderUri?: string;
+
+  /**
    * The chain ID to use
    * (default: 1 (mainnet)))
    */
   chainId?: number | string | BigInt;
+  targetChainId?: number | string | BigInt;
 
   /**
    * Axiom contract version number that we're targeting

--- a/src/v2/query/queryBuilderV2.ts
+++ b/src/v2/query/queryBuilderV2.ts
@@ -186,7 +186,6 @@ export class QueryBuilderV2 {
   setOptions(options: AxiomV2QueryOptions): AxiomV2QueryOptions {
     this.unsetBuiltQuery();
     this.options = {
-      targetChainId: BigInt(options?.targetChainId ?? this.config.chainId.toString()).toString(),
       maxFeePerGas: options?.maxFeePerGas ?? ConstantsV2.DefaultMaxFeePerGasWei,
       callbackGasLimit: options?.callbackGasLimit ?? ConstantsV2.DefaultCallbackGasLimit,
       dataQueryCalldataGasWarningThreshold:
@@ -316,7 +315,7 @@ export class QueryBuilderV2 {
 
     this.builtQuery = {
       sourceChainId: this.config.chainId.toString(),
-      targetChainId: this.options?.targetChainId ?? this.config.chainId.toString(),
+      targetChainId: this.config.targetChainId.toString(),
       queryHash,
       dataQuery,
       dataQueryHash,

--- a/src/v2/types.ts
+++ b/src/v2/types.ts
@@ -22,7 +22,6 @@ export {
 } from "@axiom-crypto/tools";
 
 export interface AxiomV2QueryOptions {
-  targetChainId?: string;
   maxFeePerGas?: string;
   callbackGasLimit?: number;
   dataQueryCalldataGasWarningThreshold?: number;

--- a/test/unit/v2/basicInitialization.test.ts
+++ b/test/unit/v2/basicInitialization.test.ts
@@ -53,62 +53,53 @@ describe("Basic Initialization", () => {
     expect(abi[0].type).toEqual("constructor");
   });
 
-  // test("should initialize QueryBuilderV2 with dataQuery", async () => {
-  //   const config: AxiomConfig = {
-  //     providerUri: process.env.PROVIDER_URI as string,
-  //     version: "v2",
-  //   };
-  //   const axiom = new Axiom(config);
-  //   const query = (axiom.query as QueryV2).new();
-  //   const dataQuery = [] as DataSubquery[];
-  //   query.append(dataQuery);
-  //   expect(typeof query).toEqual("object");
-  // });
+  test("should set targetChainId to the same as (source) chainId", () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      version: "v2",
+    };
+    const ax = new Axiom(config);
+    expect(ax.config.chainId).toEqual(ax.config.targetChainId);
+  });
 
-  // test("should initialize QueryBuilderV2 with computeQuery", async () => {
-  //   const dataQuery = [] as DataSubquery[];
-  //   const computeQuery: AxiomV2ComputeQuery = {
-  //     k: 14,
-  //     vkey,
-  //     computeProof,
-  //   };
-  //   const config: AxiomConfig = {
-  //     providerUri: process.env.PROVIDER_URI as string,
-  //     version: "v2",
-  //   };
-  //   const axiom = new Axiom(config);
-  //   const query = (axiom.query as QueryV2).new(dataQuery, computeQuery);
-  //   expect(typeof query).toEqual("object");
-  // });
+  test("should set targetProviderUri to the same as (source) providerUri", () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      version: "v2",
+    };
+    const ax = new Axiom(config);
+    expect(ax.config.providerUri).toEqual(ax.config.targetProviderUri);
+  });
 
-  // test("should initialize QueryBuilderV2 with callback", async () => {
-  //   const dataQuery = [] as DataSubquery[];
-  //   const computeQuery: AxiomV2ComputeQuery = {
-  //     k: 14,
-  //     vkey,
-  //     computeProof,
-  //   };
-  //   const callbackQuery = {
-  //     target: WETH_ADDR,
-  //     extraData: ethers.solidityPacked(["address"], [WETH_WHALE]),
-  //   };
-  //   const query = (axiom.query as QueryV2).new(dataQuery, computeQuery, callbackQuery);
-  //   expect(typeof query).toEqual("object");
-  // });
+  test("should fail if targetChainId is set while targetProviderUri is not set", () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      targetChainId: 5,
+      version: "v2",
+    };
+    expect(() => new Axiom(config)).toThrow();
+  });
 
-  // test("should initialize QueryBuilderV2 with options", async () => {
-  //   const dataQuery = [] as DataSubquery[];
-  //   const computeQuery: AxiomV2ComputeQuery = {
-  //     k: 14,
-  //     vkey,
-  //     computeProof,
-  //   };
-  //   const callbackQuery = {
-  //     target: WETH_ADDR,
-  //     extraData: ethers.solidityPacked(["address"], [WETH_WHALE]),
-  //   };
-  //   const options = {};
-  //   const query = (axiom.query as QueryV2).new(dataQuery, computeQuery, callbackQuery, options);
-  //   expect(typeof query).toEqual("object");
-  // });
+  test("should fail if targetProviderUri is set while targetChainId is not set", () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      targetProviderUri: process.env.PROVIDER_URI as string,
+      version: "v2",
+    };
+    expect(() => new Axiom(config)).toThrow();
+  });
+
+  test("should set targetChainId and targetProviderUri", () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      targetChainId: 5,
+      targetProviderUri: process.env.PROVIDER_URI_GOERLI as string,
+      version: "v2",
+    };
+    const ax = new Axiom(config);
+    expect(ax.config.chainId).toEqual(1n);
+    expect(ax.config.targetChainId).toEqual(5n);
+    expect(ax.config.providerUri).toEqual(process.env.PROVIDER_URI as string);
+    expect(ax.config.targetProviderUri).toEqual(process.env.PROVIDER_URI_GOERLI as string);
+  });
 });

--- a/test/unit/v2/crosschain.test.ts
+++ b/test/unit/v2/crosschain.test.ts
@@ -1,0 +1,58 @@
+import { 
+  Axiom,
+  AxiomConfig,
+  AxiomV2Callback,
+  HeaderField,
+  QueryV2,
+  bytes32,
+} from "../../../src";
+
+// Test coverage areas:
+// - Crosschain
+
+describe("Crosschain", () => {
+  const callback: AxiomV2Callback = {
+    target: "0x41a7a901ef58d383801272d2408276d96973550d",
+    extraData: bytes32("0xbbd0d3671093a36d6e3b608a7e3b1fdc96da1116"),
+  };
+
+  test("Build a query with a different target chain", async () => {
+    const config: AxiomConfig = {
+      providerUri: process.env.PROVIDER_URI as string,
+      targetChainId: 5,
+      targetProviderUri: process.env.PROVIDER_URI_GOERLI as string,
+      version: "v2",
+    };
+    const axiom = new Axiom(config);
+    const blockNumber = 18200000;
+    const dataQueryReq = [
+      {
+        blockNumber: blockNumber,
+        fieldIdx: HeaderField.GasUsed,
+      },
+      {
+        blockNumber: blockNumber + 100,
+        fieldIdx: HeaderField.GasUsed,
+      },
+    ];
+    const query = (axiom.query as QueryV2).new();
+    query.append(dataQueryReq);
+    query.setCallback(callback);
+
+    await query.build();
+    const builtQuery = query.getBuiltQuery();
+    if (!builtQuery) {
+      throw new Error("Query is not built");
+    }
+
+    expect(builtQuery.sourceChainId).toEqual("1");
+    expect(builtQuery.targetChainId).toEqual("5");
+    expect(builtQuery.queryHash).toEqual("0xda1933a884934070a870d18243ec2f1a7efa869966c4cf52d03b179c998a4825");
+    expect(builtQuery.dataQueryHash).toEqual("0xfaaac492509be62a2026a769d31140ee49e4b662e56c95251b8ca6ccace0e91b");
+    expect(builtQuery.dataQuery).toEqual("0x0000000000000001000200010115b5c00000000a00010115b6240000000a");
+    expect(builtQuery.computeQuery.k).toEqual(0);
+    expect(builtQuery.computeQuery.vkey.length).toEqual(0);
+    expect(builtQuery.computeQuery.vkey).toEqual([]);
+    expect(builtQuery.computeQuery.computeProof).toEqual("0x00");
+  });
+});

--- a/test/unit/v2/queryBuilderOptions.test.ts
+++ b/test/unit/v2/queryBuilderOptions.test.ts
@@ -22,20 +22,6 @@ describe("QueryBuilderV2 Options", () => {
   );
   const blockNumber = 18300000;
 
-  test("set targetChainId", async () => {
-    const query = (axiom.query as QueryV2).new();
-    const headerSubquery = buildHeaderSubquery(blockNumber).field(HeaderField.Timestamp);
-    query.appendDataSubquery(headerSubquery);
-    query.setOptions({
-      targetChainId: "31337",
-    });
-    const builtQuery = await query.build();
-    expect(builtQuery.targetChainId).toEqual("31337");
-    expect(builtQuery.maxFeePerGas).toEqual(ConstantsV2.DefaultMaxFeePerGasWei);
-    expect(builtQuery.callbackGasLimit).toEqual(ConstantsV2.DefaultCallbackGasLimit);
-    expect(builtQuery.refundee).toEqual(await wallet.getAddress());
-  });
-
   test("set maxFeePerGas", async () => {
     const query = (axiom.query as QueryV2).new();
     const headerSubquery = buildHeaderSubquery(blockNumber).field(HeaderField.Timestamp);
@@ -44,7 +30,6 @@ describe("QueryBuilderV2 Options", () => {
       maxFeePerGas: "1000000000000",
     });
     const builtQuery = await query.build();
-    expect(builtQuery.targetChainId).toEqual("1");
     expect(builtQuery.maxFeePerGas).toEqual("1000000000000");
     expect(builtQuery.callbackGasLimit).toEqual(ConstantsV2.DefaultCallbackGasLimit);
     expect(builtQuery.refundee).toEqual(await wallet.getAddress());
@@ -58,7 +43,6 @@ describe("QueryBuilderV2 Options", () => {
       callbackGasLimit: 10000,
     });
     const builtQuery = await query.build();
-    expect(builtQuery.targetChainId).toEqual("1");
     expect(builtQuery.maxFeePerGas).toEqual(ConstantsV2.DefaultMaxFeePerGasWei);
     expect(builtQuery.callbackGasLimit).toEqual(10000);
     expect(builtQuery.refundee).toEqual(await wallet.getAddress());
@@ -72,7 +56,6 @@ describe("QueryBuilderV2 Options", () => {
       refundee: "0xe76a90E3069c9d86e666DcC687e76fcecf4429cF",
     });
     const builtQuery = await query.build();
-    expect(builtQuery.targetChainId).toEqual("1");
     expect(builtQuery.maxFeePerGas).toEqual(ConstantsV2.DefaultMaxFeePerGasWei);
     expect(builtQuery.callbackGasLimit).toEqual(ConstantsV2.DefaultCallbackGasLimit);
     expect(builtQuery.refundee).toEqual("0xe76a90E3069c9d86e666DcC687e76fcecf4429cF");

--- a/test/unit/v2/queryV2.test.ts
+++ b/test/unit/v2/queryV2.test.ts
@@ -35,7 +35,6 @@ import {
 } from "../../../src";
 import { QueryV2 } from "../../../src/v2/query/queryV2";
 import { ethers } from "ethers";
-import { resizeArray } from "../../../src/shared/utils";
 
 describe("QueryV2", () => {
   const BLOCK_NUMBER = 15537394;


### PR DESCRIPTION
- Moves targetChainId and targetProviderUri to Axiom class init
- Adds tests for targetChainId before and after building the Query