### PR TITLE
`@axiom-crypto/tools` passthrough export

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,1 @@
+export * from "@axiom-crypto/tools";


### PR DESCRIPTION
- Complete passthrough export for `@axiom-crypto/tools`
- Users can import via `import { ... } from '@axiom-crypto/core/tools'` 